### PR TITLE
Sky DE 2020

### DIFF
--- a/config/siteini.pack/Germany/sky.de.channels.xml
+++ b/config/siteini.pack/Germany/sky.de.channels.xml
@@ -1,32 +1,22 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <site generator-info-name="WebGrab+Plus/w MDB &amp; REX Postprocess -- version V1.56.24 -- Jan van Straaten" site="sky.de">
   <channels>
+    <channel update="i" site="sky.de" site_id="535" xmltv_id="Sky One HD">Sky One HD</channel>
     <channel update="i" site="sky.de" site_id="2" xmltv_id="Sky Atlantic HD">Sky Atlantic HD</channel>
-    <channel update="i" site="sky.de" site_id="498" xmltv_id="Sky Atlantic+1 HD">Sky Atlantic+1 HD</channel>
     <channel update="i" site="sky.de" site_id="4" xmltv_id="Fox HD">Fox HD</channel>
     <channel update="i" site="sky.de" site_id="6" xmltv_id="TNT Serie HD">TNT Serie HD</channel>
-    <channel update="i" site="sky.de" site_id="446" xmltv_id="RTL Crime HD">RTL Crime HD</channel>
     <channel update="i" site="sky.de" site_id="115" xmltv_id="Syfy HD">Syfy HD</channel>
+    <channel update="i" site="sky.de" site_id="9" xmltv_id="13th Street">13th Street</channel>
     <channel update="i" site="sky.de" site_id="116" xmltv_id="13th Street HD">13th Street HD</channel>
-    <channel update="i" site="sky.de" site_id="13" xmltv_id="AXN HD">AXN HD</channel>
-    <channel update="i" site="sky.de" site_id="172" xmltv_id="Universal HD">Universal HD</channel>
+    <channel update="i" site="sky.de" site_id="172" xmltv_id="Universal TV HD">Universal TV HD</channel>
+    <channel update="i" site="sky.de" site_id="674" xmltv_id="TNT Comedy">TNT Comedy</channel>
     <channel update="i" site="sky.de" site_id="522" xmltv_id="TNT Comedy HD">TNT Comedy HD</channel>
     <channel update="i" site="sky.de" site_id="117" xmltv_id="E! Entertainm. HD">E! Entertainm. HD</channel>
-    <channel update="i" site="sky.de" site_id="175" xmltv_id="Pro7 FUN HD">Pro7 FUN HD</channel>
-    <channel update="i" site="sky.de" site_id="1" xmltv_id="Sky Krimi">Sky Krimi</channel>
+    <channel update="i" site="sky.de" site_id="753" xmltv_id="Sky Krimi HD">Sky Krimi HD</channel>
     <channel update="i" site="sky.de" site_id="174" xmltv_id="Sky Atlantic">Sky Atlantic</channel>
-    <channel update="i" site="sky.de" site_id="3" xmltv_id="Fox Serie">Fox Serie</channel>
-    <channel update="i" site="sky.de" site_id="5" xmltv_id="TNT Serie">TNT Serie</channel>
-    <channel update="i" site="sky.de" site_id="7" xmltv_id="RTL Crime">RTL Crime</channel>
-    <channel update="i" site="sky.de" site_id="8" xmltv_id="Syfy">Syfy</channel>
-    <channel update="i" site="sky.de" site_id="9" xmltv_id="13th Street">13th Street</channel>
-    <channel update="i" site="sky.de" site_id="11" xmltv_id="RTL Passion">RTL Passion</channel>
-    <channel update="i" site="sky.de" site_id="10" xmltv_id="RTL Living">RTL Living</channel>
-    <channel update="i" site="sky.de" site_id="12" xmltv_id="AXN Action">AXN Action</channel>
-    <channel update="i" site="sky.de" site_id="14" xmltv_id="Animax">Animax</channel>
-    <channel update="i" site="sky.de" site_id="15" xmltv_id="SAT.1 emotions">SAT.1 emotions</channel>
     <channel update="i" site="sky.de" site_id="16" xmltv_id="Romance TV">Romance TV</channel>
     <channel update="i" site="sky.de" site_id="17" xmltv_id="Sky Sport News HD">Sky Sport News HD</channel>
+    <channel update="i" site="sky.de" site_id="531" xmltv_id="Sky Bundesliga UHD">Sky Bundesliga UHD</channel>
     <channel update="i" site="sky.de" site_id="118" xmltv_id="Sky Bundesliga HD 1">Sky Bundesliga HD 1</channel>
     <channel update="i" site="sky.de" site_id="119" xmltv_id="Sky Bundesliga HD 2">Sky Bundesliga HD 2</channel>
     <channel update="i" site="sky.de" site_id="120" xmltv_id="Sky Bundesliga HD 3">Sky Bundesliga HD 3</channel>
@@ -37,22 +27,25 @@
     <channel update="i" site="sky.de" site_id="125" xmltv_id="Sky Bundesliga HD 8">Sky Bundesliga HD 8</channel>
     <channel update="i" site="sky.de" site_id="126" xmltv_id="Sky Bundesliga HD 9">Sky Bundesliga HD 9</channel>
     <channel update="i" site="sky.de" site_id="127" xmltv_id="Sky Bundesliga HD 10">Sky Bundesliga HD 10</channel>
-    <channel update="i" site="sky.de" site_id="128" xmltv_id="Sky Sport HD 1">Sky Sport HD 1</channel>
-    <channel update="i" site="sky.de" site_id="129" xmltv_id="Sky Sport HD 2">Sky Sport HD 2</channel>
-    <channel update="i" site="sky.de" site_id="130" xmltv_id="Sky Sport HD 3">Sky Sport HD 3</channel>
-    <channel update="i" site="sky.de" site_id="131" xmltv_id="Sky Sport HD 4">Sky Sport HD 4</channel>
-    <channel update="i" site="sky.de" site_id="132" xmltv_id="Sky Sport HD 5">Sky Sport HD 5</channel>
-    <channel update="i" site="sky.de" site_id="133" xmltv_id="Sky Sport HD 6">Sky Sport HD 6</channel>
-    <channel update="i" site="sky.de" site_id="134" xmltv_id="Sky Sport HD 7">Sky Sport HD 7</channel>
-    <channel update="i" site="sky.de" site_id="135" xmltv_id="Sky Sport HD 8">Sky Sport HD 8</channel>
-    <channel update="i" site="sky.de" site_id="136" xmltv_id="Sky Sport HD 9">Sky Sport HD 9</channel>
-    <channel update="i" site="sky.de" site_id="137" xmltv_id="Sky Sport HD 10">Sky Sport HD 10</channel>
-    <channel update="i" site="sky.de" site_id="138" xmltv_id="Sky Sport HD 11">Sky Sport HD 11</channel>
+    <channel update="i" site="sky.de" site_id="128" xmltv_id="Sky Sport 1 HD">Sky Sport 1 HD</channel>
+    <channel update="i" site="sky.de" site_id="129" xmltv_id="Sky Sport 2 HD">Sky Sport 2 HD</channel>
+    <channel update="i" site="sky.de" site_id="130" xmltv_id="Sky Sport 3 HD">Sky Sport 3 HD</channel>
+    <channel update="i" site="sky.de" site_id="131" xmltv_id="Sky Sport 4 HD">Sky Sport 4 HD</channel>
+    <channel update="i" site="sky.de" site_id="132" xmltv_id="Sky Sport 5 HD">Sky Sport 5 HD</channel>
+    <channel update="i" site="sky.de" site_id="133" xmltv_id="Sky Sport 6 HD">Sky Sport 6 HD</channel>
+    <channel update="i" site="sky.de" site_id="134" xmltv_id="Sky Sport 7 HD">Sky Sport 7 HD</channel>
+    <channel update="i" site="sky.de" site_id="135" xmltv_id="Sky Sport 8 HD">Sky Sport 8 HD</channel>
+    <channel update="i" site="sky.de" site_id="136" xmltv_id="Sky Sport 9 HD">Sky Sport 9 HD</channel>
+    <channel update="i" site="sky.de" site_id="137" xmltv_id="Sky Sport 10 HD">Sky Sport 10 HD</channel>
+    <channel update="i" site="sky.de" site_id="138" xmltv_id="Sky Sport 11 HD">Sky Sport 11 HD</channel>
+    <channel update="i" site="sky.de" site_id="567" xmltv_id="Sky Sport 12 HD">Sky Sport 12 HD</channel>
+    <channel update="i" site="sky.de" site_id="568" xmltv_id="Sky Sport 13 HD">Sky Sport 13 HD</channel>
+    <channel update="i" site="sky.de" site_id="569" xmltv_id="Sky Sport 14 HD">Sky Sport 14 HD</channel>
     <channel update="i" site="sky.de" site_id="492" xmltv_id="Sky Sport Austria HD">Sky Sport Austria HD</channel>
-    <channel update="i" site="sky.de" site_id="162" xmltv_id="Sport1 US HD">Sport1 US HD</channel>
-    <channel update="i" site="sky.de" site_id="173" xmltv_id="Sport1 US HD 1">Sport1 US HD 1</channel>
-    <channel update="i" site="sky.de" site_id="53" xmltv_id="Sport1+ HD">Sport1+ HD</channel>
-    <channel update="i" site="sky.de" site_id="51" xmltv_id="Eurosport 1 HD">Eurosport 1 HD</channel>
+    <channel update="i" site="sky.de" site_id="729" xmltv_id="Sky Sport Austria 2 HD">Sky Sport Austria 2 HD</channel>
+    <channel update="i" site="sky.de" site_id="730" xmltv_id="Sky Sport Austria 3 HD">Sky Sport Austria 3 HD</channel>
+    <channel update="i" site="sky.de" site_id="731" xmltv_id="Sky Sport Austria 4 HD">Sky Sport Austria 4 HD</channel>
+    <channel update="i" site="sky.de" site_id="596" xmltv_id="Eurosport 1 HD">Eurosport 1 HD</channel>
     <channel update="i" site="sky.de" site_id="161" xmltv_id="Eurosport 2 HD">Eurosport 2 HD</channel>
     <channel update="i" site="sky.de" site_id="163" xmltv_id="Eurosport360HD 1">Eurosport360HD 1</channel>
     <channel update="i" site="sky.de" site_id="164" xmltv_id="Eurosport360HD 2">Eurosport360HD 2</channel>
@@ -74,42 +67,46 @@
     <channel update="i" site="sky.de" site_id="146" xmltv_id="Sky Bundesliga 8">Sky Bundesliga 8</channel>
     <channel update="i" site="sky.de" site_id="147" xmltv_id="Sky Bundesliga 9">Sky Bundesliga 9</channel>
     <channel update="i" site="sky.de" site_id="148" xmltv_id="Sky Bundesliga 10">Sky Bundesliga 10</channel>
-    <channel update="i" site="sky.de" site_id="149" xmltv_id="Sky Sport  1">Sky Sport  1</channel>
-    <channel update="i" site="sky.de" site_id="150" xmltv_id="Sky Sport  2">Sky Sport  2</channel>
-    <channel update="i" site="sky.de" site_id="151" xmltv_id="Sky Sport  3">Sky Sport  3</channel>
-    <channel update="i" site="sky.de" site_id="152" xmltv_id="Sky Sport  4">Sky Sport  4</channel>
-    <channel update="i" site="sky.de" site_id="153" xmltv_id="Sky Sport  5">Sky Sport  5</channel>
-    <channel update="i" site="sky.de" site_id="154" xmltv_id="Sky Sport  6">Sky Sport  6</channel>
-    <channel update="i" site="sky.de" site_id="155" xmltv_id="Sky Sport  7">Sky Sport  7</channel>
-    <channel update="i" site="sky.de" site_id="156" xmltv_id="Sky Sport  8">Sky Sport  8</channel>
-    <channel update="i" site="sky.de" site_id="157" xmltv_id="Sky Sport  9">Sky Sport  9</channel>
-    <channel update="i" site="sky.de" site_id="158" xmltv_id="Sky Sport  10">Sky Sport  10</channel>
-    <channel update="i" site="sky.de" site_id="159" xmltv_id="Sky Sport  11">Sky Sport  11</channel>
+    <channel update="i" site="sky.de" site_id="149" xmltv_id="Sky Sport 1">Sky Sport 1</channel>
+    <channel update="i" site="sky.de" site_id="150" xmltv_id="Sky Sport 2">Sky Sport 2</channel>
+    <channel update="i" site="sky.de" site_id="151" xmltv_id="Sky Sport 3">Sky Sport 3</channel>
+    <channel update="i" site="sky.de" site_id="152" xmltv_id="Sky Sport 4">Sky Sport 4</channel>
+    <channel update="i" site="sky.de" site_id="153" xmltv_id="Sky Sport 5">Sky Sport 5</channel>
+    <channel update="i" site="sky.de" site_id="154" xmltv_id="Sky Sport 6">Sky Sport 6</channel>
+    <channel update="i" site="sky.de" site_id="155" xmltv_id="Sky Sport 7">Sky Sport 7</channel>
+    <channel update="i" site="sky.de" site_id="156" xmltv_id="Sky Sport 8">Sky Sport 8</channel>
+    <channel update="i" site="sky.de" site_id="157" xmltv_id="Sky Sport 9">Sky Sport 9</channel>
+    <channel update="i" site="sky.de" site_id="158" xmltv_id="Sky Sport 10">Sky Sport 10</channel>
     <channel update="i" site="sky.de" site_id="47" xmltv_id="Sky Sport Austria">Sky Sport Austria</channel>
-    <channel update="i" site="sky.de" site_id="114" xmltv_id="Sportdigital HD">Sportdigital HD</channel>
-    <channel update="i" site="sky.de" site_id="56" xmltv_id="Sky Cinema HD">Sky Cinema HD</channel>
-    <channel update="i" site="sky.de" site_id="447" xmltv_id="Sky Cinema+1 HD">Sky Cinema+1 HD</channel>
-    <channel update="i" site="sky.de" site_id="448" xmltv_id="Sky Cinema+24 HD">Sky Cinema+24 HD</channel>
-    <channel update="i" site="sky.de" site_id="65" xmltv_id="Sky Hits HD">Sky Hits HD</channel>
-    <channel update="i" site="sky.de" site_id="60" xmltv_id="Sky Action HD">Sky Action HD</channel>
-    <channel update="i" site="sky.de" site_id="67" xmltv_id="Disney Cinemagic HD">Disney Cinemagic HD</channel>
-    <channel update="i" site="sky.de" site_id="160" xmltv_id="MGM HD">MGM HD</channel>
-    <channel update="i" site="sky.de" site_id="54" xmltv_id="Sky 3D">Sky 3D</channel>
-    <channel update="i" site="sky.de" site_id="55" xmltv_id="Sky Cinema">Sky Cinema</channel>
-    <channel update="i" site="sky.de" site_id="57" xmltv_id="Sky Cinema+1">Sky Cinema+1</channel>
-    <channel update="i" site="sky.de" site_id="58" xmltv_id="Sky Cinema+24">Sky Cinema+24</channel>
-    <channel update="i" site="sky.de" site_id="64" xmltv_id="Sky Hits">Sky Hits</channel>
-    <channel update="i" site="sky.de" site_id="59" xmltv_id="Sky Action">Sky Action</channel>
-    <channel update="i" site="sky.de" site_id="61" xmltv_id="Sky Comedy">Sky Comedy</channel>
-    <channel update="i" site="sky.de" site_id="62" xmltv_id="Sky Emotion">Sky Emotion</channel>
-    <channel update="i" site="sky.de" site_id="63" xmltv_id="Sky Nostalgie">Sky Nostalgie</channel>
-    <channel update="i" site="sky.de" site_id="66" xmltv_id="Disney Cinemagic">Disney Cinemagic</channel>
+    <channel update="i" site="sky.de" site_id="732" xmltv_id="Sky Sport Austria 2">Sky Sport Austria 2</channel>
+    <channel update="i" site="sky.de" site_id="733" xmltv_id="Sky Sport Austria 3">Sky Sport Austria 3</channel>
+    <channel update="i" site="sky.de" site_id="734" xmltv_id="Sky Sport Austria 4">Sky Sport Austria 3</channel>
+    <channel update="i" site="sky.de" site_id="114" xmltv_id="Sportdigital Fussball">Sportdigital Fussball</channel>
+    <channel update="i" site="sky.de" site_id="787" xmltv_id="Sky Cinema Premieren">Sky Cinema Premieren</channel>
+    <channel update="i" site="sky.de" site_id="762" xmltv_id="TNT Film">TNT Film</channel>
+    <channel update="i" site="sky.de" site_id="689" xmltv_id="TNT Film HD">TNT Film HD</channel>
+    <channel update="i" site="sky.de" site_id="784" xmltv_id="Sky Thriller HD">Sky Cinema Thriller HD</channel>
+    <channel update="i" site="sky.de" site_id="788" xmltv_id="Sky Cinema Premieren HD">Sky Cinema Premieren HD</channel>
+    <channel update="i" site="sky.de" site_id="789" xmltv_id="Sky Cinema Premieren+24">Sky Cinema Premieren+24</channel>
+    <channel update="i" site="sky.de" site_id="791" xmltv_id="Sky Cinema Premieren+24 HD">Sky Cinema Premieren+24 HD</channel>
+    <channel update="i" site="sky.de" site_id="790" xmltv_id="Sky Cinema Best Of">Sky Cinema Best Of</channel>
+    <channel update="i" site="sky.de" site_id="792" xmltv_id="Sky Cinema Best Of HD">Sky Cinema Best Of HD</channel>
+    <channel update="i" site="sky.de" site_id="756" xmltv_id="Sky Cinema Special HD">Sky Cinema Special HD</channel>
+    <channel update="i" site="sky.de" site_id="59" xmltv_id="Sky Cinema Action">Sky Action</channel>
+    <channel update="i" site="sky.de" site_id="60" xmltv_id="Sky Cinema Action HD">Sky Action HD</channel>
+    <channel update="i" site="sky.de" site_id="793" xmltv_id="Sky Cinema Fun">Sky Cinema Fun</channel>
+    <channel update="i" site="sky.de" site_id="532" xmltv_id="Sky Cinema Family">Sky Cinema Family</channel>
+    <channel update="i" site="sky.de" site_id="533" xmltv_id="Sky Cinema Family">Sky Cinema Family HD</channel>
+    <channel update="i" site="sky.de" site_id="794" xmltv_id="Sky Cinema Classics">Sky Cinema Classics</channel>
+    <channel update="i" site="sky.de" site_id="742" xmltv_id="Sky Serien A&amp; Shows HD">="Sky Serien A&amp; Shows HD</channel>
+    <channel update="i" site="sky.de" site_id="783" xmltv_id="Nick.Jr.">Nick.Jr.</channel>
+    <channel update="i" site="sky.de" site_id="798" xmltv_id="nicktoons">Nick.Jr.</channel>
     <channel update="i" site="sky.de" site_id="68" xmltv_id="MGM">MGM</channel>
     <channel update="i" site="sky.de" site_id="72" xmltv_id="Heimatkanal">Heimatkanal</channel>
-    <channel update="i" site="sky.de" site_id="69" xmltv_id="TNT Film (TCM)">TNT Film (TCM)</channel>
     <channel update="i" site="sky.de" site_id="70" xmltv_id="Kinowelt TV">Kinowelt TV</channel>
     <channel update="i" site="sky.de" site_id="71" xmltv_id="kabel eins classics">kabel eins classics</channel>
     <channel update="i" site="sky.de" site_id="73" xmltv_id="Beate-Uhse.TV">Beate-Uhse.TV</channel>
+    <channel update="i" site="sky.de" site_id="690" xmltv_id="Beate-Uhse.TV HD">Beate-Uhse.TV HD</channel>
     <channel update="i" site="sky.de" site_id="113" xmltv_id="Sky Select HD">Sky Select HD</channel>
     <channel update="i" site="sky.de" site_id="102" xmltv_id="Sky Select 1">Sky Select 1</channel>
     <channel update="i" site="sky.de" site_id="103" xmltv_id="Sky Select 2">Sky Select 2</channel>
@@ -122,22 +119,17 @@
     <channel update="i" site="sky.de" site_id="110" xmltv_id="Sky Select 9">Sky Select 9</channel>
     <channel update="i" site="sky.de" site_id="111" xmltv_id="Sky Select Event A">Sky Select Event A</channel>
     <channel update="i" site="sky.de" site_id="112" xmltv_id="Sky Select Event B">Sky Select Event B</channel>
-    <channel update="i" site="sky.de" site_id="81" xmltv_id="NatGeo HD">NatGeo HD</channel>
+    <channel update="i" site="sky.de" site_id="81" xmltv_id="National Geographic HD">National Geographic HD</channel>
     <channel update="i" site="sky.de" site_id="88" xmltv_id="NatGeo Wild HD">NatGeo Wild HD</channel>
+    <channel update="i" site="sky.de" site_id="84" xmltv_id="Spiegel Geschichte">Spiegel Geschichte</channel>
     <channel update="i" site="sky.de" site_id="388" xmltv_id="Spiegel Geschichte HD">Spiegel Geschichte HD</channel>
+    <channel update="i" site="sky.de" site_id="658" xmltv_id="Spiegel TV Wissen">Spiegel TV Wissen</channel>
     <channel update="i" site="sky.de" site_id="86" xmltv_id="History HD">History HD</channel>
     <channel update="i" site="sky.de" site_id="83" xmltv_id="Discovery HD">Discovery HD</channel>
     <channel update="i" site="sky.de" site_id="52" xmltv_id="Motorvision TV">Motorvision TV</channel>
-    <channel update="i" site="sky.de" site_id="451" xmltv_id="A&amp;E">A&amp;E</channel>
-    <channel update="i" site="sky.de" site_id="82" xmltv_id="Discovery Channel">Discovery Channel</channel>
-    <channel update="i" site="sky.de" site_id="80" xmltv_id="National Geographic">National Geographic</channel>
-    <channel update="i" site="sky.de" site_id="87" xmltv_id="NatGeo Wild">NatGeo Wild</channel>
-    <channel update="i" site="sky.de" site_id="84" xmltv_id="Spiegel Geschichte">Spiegel Geschichte</channel>
-    <channel update="i" site="sky.de" site_id="387" xmltv_id="Disney Junior HD">Disney Junior HD</channel>
-    <channel update="i" site="sky.de" site_id="92" xmltv_id="Disney Junior">Disney Junior</channel>
-    <channel update="i" site="sky.de" site_id="93" xmltv_id="Disney XD">Disney XD</channel>
+    <channel update="i" site="sky.de" site_id="451" xmltv_id="Crime + Investigation">Crime + Investigation</channel>
     <channel update="i" site="sky.de" site_id="96" xmltv_id="Junior">Junior</channel>
-    <channel update="i" site="sky.de" site_id="94" xmltv_id="Boomerang">Boomerang</channel>
+    <channel update="i" site="sky.de" site_id="761" xmltv_id="Boomerang">Boomerang</channel>
     <channel update="i" site="sky.de" site_id="95" xmltv_id="Cartoon Network">Cartoon Network</channel>
     <channel update="i" site="sky.de" site_id="452" xmltv_id="Jukebox">Jukebox</channel>
     <channel update="i" site="sky.de" site_id="98" xmltv_id="Goldstar TV">Goldstar TV</channel>

--- a/config/siteini.pack/Germany/sky.de.channels.xml
+++ b/config/siteini.pack/Germany/sky.de.channels.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <site generator-info-name="WebGrab+Plus/w MDB &amp; REX Postprocess -- version V1.56.24 -- Jan van Straaten" site="sky.de">
   <channels>
     <channel update="i" site="sky.de" site_id="535" xmltv_id="Sky One HD">Sky One HD</channel>
@@ -6,14 +6,12 @@
     <channel update="i" site="sky.de" site_id="4" xmltv_id="Fox HD">Fox HD</channel>
     <channel update="i" site="sky.de" site_id="6" xmltv_id="TNT Serie HD">TNT Serie HD</channel>
     <channel update="i" site="sky.de" site_id="115" xmltv_id="Syfy HD">Syfy HD</channel>
-    <channel update="i" site="sky.de" site_id="9" xmltv_id="13th Street">13th Street</channel>
     <channel update="i" site="sky.de" site_id="116" xmltv_id="13th Street HD">13th Street HD</channel>
     <channel update="i" site="sky.de" site_id="172" xmltv_id="Universal TV HD">Universal TV HD</channel>
     <channel update="i" site="sky.de" site_id="674" xmltv_id="TNT Comedy">TNT Comedy</channel>
     <channel update="i" site="sky.de" site_id="522" xmltv_id="TNT Comedy HD">TNT Comedy HD</channel>
     <channel update="i" site="sky.de" site_id="117" xmltv_id="E! Entertainm. HD">E! Entertainm. HD</channel>
     <channel update="i" site="sky.de" site_id="753" xmltv_id="Sky Krimi HD">Sky Krimi HD</channel>
-    <channel update="i" site="sky.de" site_id="174" xmltv_id="Sky Atlantic">Sky Atlantic</channel>
     <channel update="i" site="sky.de" site_id="16" xmltv_id="Romance TV">Romance TV</channel>
     <channel update="i" site="sky.de" site_id="17" xmltv_id="Sky Sport News HD">Sky Sport News HD</channel>
     <channel update="i" site="sky.de" site_id="531" xmltv_id="Sky Bundesliga UHD">Sky Bundesliga UHD</channel>
@@ -47,15 +45,15 @@
     <channel update="i" site="sky.de" site_id="731" xmltv_id="Sky Sport Austria 4 HD">Sky Sport Austria 4 HD</channel>
     <channel update="i" site="sky.de" site_id="596" xmltv_id="Eurosport 1 HD">Eurosport 1 HD</channel>
     <channel update="i" site="sky.de" site_id="161" xmltv_id="Eurosport 2 HD">Eurosport 2 HD</channel>
-    <channel update="i" site="sky.de" site_id="163" xmltv_id="Eurosport360HD 1">Eurosport360HD 1</channel>
-    <channel update="i" site="sky.de" site_id="164" xmltv_id="Eurosport360HD 2">Eurosport360HD 2</channel>
-    <channel update="i" site="sky.de" site_id="165" xmltv_id="Eurosport360HD 3">Eurosport360HD 3</channel>
-    <channel update="i" site="sky.de" site_id="166" xmltv_id="Eurosport360HD 4">Eurosport360HD 4</channel>
-    <channel update="i" site="sky.de" site_id="167" xmltv_id="Eurosport360HD 5">Eurosport360HD 5</channel>
-    <channel update="i" site="sky.de" site_id="168" xmltv_id="Eurosport360HD 6">Eurosport360HD 6</channel>
-    <channel update="i" site="sky.de" site_id="169" xmltv_id="Eurosport360HD 7">Eurosport360HD 7</channel>
-    <channel update="i" site="sky.de" site_id="170" xmltv_id="Eurosport360HD 8">Eurosport360HD 8</channel>
-    <channel update="i" site="sky.de" site_id="171" xmltv_id="Eurosport360HD 9">Eurosport360HD 9</channel>
+    <channel update="i" site="sky.de" site_id="163" xmltv_id="Eurosport360 HD 1">Eurosport360 HD 1</channel>
+    <channel update="i" site="sky.de" site_id="164" xmltv_id="Eurosport360 HD 2">Eurosport360 HD 2</channel>
+    <channel update="i" site="sky.de" site_id="165" xmltv_id="Eurosport360 HD 3">Eurosport360 HD 3</channel>
+    <channel update="i" site="sky.de" site_id="166" xmltv_id="Eurosport360 HD 4">Eurosport360 HD 4</channel>
+    <channel update="i" site="sky.de" site_id="167" xmltv_id="Eurosport360 HD 5">Eurosport360 HD 5</channel>
+    <channel update="i" site="sky.de" site_id="168" xmltv_id="Eurosport360 HD 6">Eurosport360 HD 6</channel>
+    <channel update="i" site="sky.de" site_id="169" xmltv_id="Eurosport360 HD 7">Eurosport360 HD 7</channel>
+    <channel update="i" site="sky.de" site_id="170" xmltv_id="Eurosport360 HD 8">Eurosport360 HD 8</channel>
+    <channel update="i" site="sky.de" site_id="171" xmltv_id="Eurosport360 HD 9">Eurosport360 HD 9</channel>
     <channel update="i" site="sky.de" site_id="21" xmltv_id="Sky Sport News">Sky Sport News</channel>
     <channel update="i" site="sky.de" site_id="139" xmltv_id="Sky Bundesliga 1">Sky Bundesliga 1</channel>
     <channel update="i" site="sky.de" site_id="140" xmltv_id="Sky Bundesliga 2">Sky Bundesliga 2</channel>
@@ -98,14 +96,12 @@
     <channel update="i" site="sky.de" site_id="532" xmltv_id="Sky Cinema Family">Sky Cinema Family</channel>
     <channel update="i" site="sky.de" site_id="533" xmltv_id="Sky Cinema Family">Sky Cinema Family HD</channel>
     <channel update="i" site="sky.de" site_id="794" xmltv_id="Sky Cinema Classics">Sky Cinema Classics</channel>
-    <channel update="i" site="sky.de" site_id="742" xmltv_id="Sky Serien A&amp; Shows HD">="Sky Serien A&amp; Shows HD</channel>
-    <channel update="i" site="sky.de" site_id="783" xmltv_id="Nick.Jr.">Nick.Jr.</channel>
-    <channel update="i" site="sky.de" site_id="798" xmltv_id="nicktoons">Nick.Jr.</channel>
-    <channel update="i" site="sky.de" site_id="68" xmltv_id="MGM">MGM</channel>
+    <channel update="i" site="sky.de" site_id="742" xmltv_id="Sky Serien &amp; Shows HD">Sky Serien &amp; Shows HD</channel>
+    <channel update="i" site="sky.de" site_id="783" xmltv_id="Nick Jr.">Nick Jr.</channel>
+    <channel update="i" site="sky.de" site_id="798" xmltv_id="nicktoons">nicktoons</channel>
     <channel update="i" site="sky.de" site_id="72" xmltv_id="Heimatkanal">Heimatkanal</channel>
     <channel update="i" site="sky.de" site_id="70" xmltv_id="Kinowelt TV">Kinowelt TV</channel>
     <channel update="i" site="sky.de" site_id="71" xmltv_id="kabel eins classics">kabel eins classics</channel>
-    <channel update="i" site="sky.de" site_id="73" xmltv_id="Beate-Uhse.TV">Beate-Uhse.TV</channel>
     <channel update="i" site="sky.de" site_id="690" xmltv_id="Beate-Uhse.TV HD">Beate-Uhse.TV HD</channel>
     <channel update="i" site="sky.de" site_id="113" xmltv_id="Sky Select HD">Sky Select HD</channel>
     <channel update="i" site="sky.de" site_id="102" xmltv_id="Sky Select 1">Sky Select 1</channel>


### PR DESCRIPTION
Fixed - new Sky stations in September 2020, removed Disney, RTL, Sat.1, ProSieben,...